### PR TITLE
fixed typo in tvc bootstrap rms::cph() call

### DIFF
--- a/R/coxed.R
+++ b/R/coxed.R
@@ -224,7 +224,7 @@ coxed <- function(cox.model, newdata=NULL, newdata2=NULL, bootstrap=FALSE, metho
                          as.numeric(cox.model$y[ , 3]),
                          type = "counting")
                Xmat <- model.matrix(cox.model)
-               boot.cph <- rms::cph(S ~ X, x = TRUE, y = TRUE)
+               boot.cph <- rms::cph(S ~ Xmat, x = TRUE, y = TRUE)
                class(boot.cph) <- "tvc"
                boot.model <- bootcov2(boot.cph, B = B, cluster=id, ...)
           }


### PR DESCRIPTION
Hi, thanks for your great work on this package. There was a small typo in the cph() call in the bootstrap code chunk for time varying covariates.